### PR TITLE
Ignore node_modules in volume and add prisma instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ COPY package*.json .
 FROM base as dev
 RUN npm i
 COPY . .
+RUN npm run generate
 CMD ["npm", "run", "dev"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ My personal website and blog. Built with [TypeScript](https://www.typescriptlang
 - `git clone https://github.com/alexnault/alexnault.dev.git`
 - `cd alexnault.dev`
 - `npm i`
+- `npm run generate`
 - `npm run dev`
 - Open [localhost:3000](https://localhost:3000)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,4 @@ services:
       - 3000:3000
     volumes:
       - ./:/app
+      - /app/node_modules/ # Use anonymous volume to ignore node_modules

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "postbuild": "next-sitemap --config next-sitemap-config.js",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier --write \"{components,pages,lib}/**/*.{js,jsx,ts,tsx}\""
+    "format": "prettier --write \"{components,pages,lib}/**/*.{js,jsx,ts,tsx}\"",
+    "generate": "prisma generate"
   },
   "dependencies": {
     "@headlessui/react": "^1.4.1",


### PR DESCRIPTION
node_modules needs to be left out of the volume for `sharp` to work with different env (win/linux) between docker host and container. And since prisma's output isn't copied over to the container anymore, building the image needs to generate the client in node_modules itself